### PR TITLE
Fix for race condition during connection close

### DIFF
--- a/django_sentinel/sentinel.py
+++ b/django_sentinel/sentinel.py
@@ -109,13 +109,13 @@ class SentinelClient(DefaultClient):
         """
         self.log.debug("close called")
         if self._client_read:
-            for c in self._client_read.connection_pool._available_connections:
-                c.disconnect()
+            self._client_read.connection_pool.disconnect(
+                inuse_connections=False)
             self.log.debug("client_read closed")
 
         if self._client_write:
-            for c in self._client_write.connection_pool._available_connections:
-                c.disconnect()
+            self._client_write.connection_pool.disconnect(
+                inuse_connections=False)
             self.log.debug("client_write closed")
 
         del(self._client_write)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     url="https://github.com/lamoda/django-sentinel",
     author="Aleksey Partilov",
     author_email="aleksey.partilov@lamoda.ru",
-    version="0.1.1",
+    version="0.1.2",
     packages=[
         "django_sentinel",
     ],


### PR DESCRIPTION
During client closing client is iterating through internal connection pool, bypassing internal lock in connection pool. In case of multithreaded uwsgi setup this leads to race condition. Connections are closed while being used by another thread. This can lead to issues similar to described in this ticket: https://github.com/andymccurdy/redis-py/issues/1345

This change uses `disconnect()` method from connection pool instead, which uses internal lock to prevent race condition.